### PR TITLE
docs: add Nutrient document processing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Skills work across multiple platforms:
 
 - [d3-visualization](https://github.com/ComposioHQ/awesome-claude-skills#data-visualization) - D3.js data visualization Skill.
 - [context-engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - Context engineering and multi-Agent architecture.
+- [Nutrient Document Processing](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Full document-processing skill via Nutrient DWS: convert PDF/Office/images, OCR, extract text/tables/key-values, redact PII (pattern+AI), watermark, sign, merge/split/reorder, and form fill.
 
 ## Writing
 


### PR DESCRIPTION
Adds Nutrient Document Processing skill under Data Processing.

Repo: https://github.com/PSPDFKit-labs/nutrient-agent-skill

Expanded description covers full capabilities, including:
- Conversion (DOCX/XLSX/PPTX/HTML/image ↔ PDF)
- OCR and text/table/key-value extraction
- Redaction (pattern-based + AI)
- Watermarking and digital signatures
- Merge/split/reorder, form fill, and related document workflows
