### PR TITLE
feat: add Media & Voice section with NoizAI/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ English | [简体中文](README_ZH.md)
 - [Data Processing](#data-processing)
 - [Writing](#writing)
 - [Design](#design)
+- [Media & Voice](#media--voice)
 
 ## Quick Start
 
@@ -161,6 +162,10 @@ Skills work across multiple platforms:
 - [theme-factory](https://github.com/anthropics/skills/tree/main/skills/theme-factory) - Theme style factory Skill.
 - [algorithmic-art](https://github.com/anthropics/skills/tree/main/skills/algorithmic-art) - Algorithmic art generation Skill.
 - [slack-gif-creator](https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator) - Slack GIF creator Skill.
+
+## Media & Voice
+
+- [NoizAI/skills](https://github.com/NoizAI/skills) - Human-like TTS skills with emotion controls, local/cloud backends, and one-command voice delivery to chat apps.
 
 ## Contributing
 


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to propose a new **Media & Voice** section, starting with [NoizAI/skills](https://github.com/NoizAI/skills) — a practical skill collection for human-like TTS workflows.

Why this fits:
- Validated speaking-style guidance (fillers, emotional tone, pacing presets).
- Works across real delivery scenarios: voice generation → chat apps / broadcasting.
- Developer-friendly local + cloud backend options.

Quick try:
- `npx skills add NoizAI/skills --list --full-depth`
- `npx skills add NoizAI/skills --full-depth --skill tts -y`

If you'd prefer to place it under an existing section (e.g. Productivity), happy to adjust!

Made with [Cursor](https://cursor.com)