### PR TITLE
Add rails-conventions skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Skills work across multiple platforms:
 
 ## Development Tools
 
+[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions) - Rails 8 conventions + implementation/review guidance.
+
 - [claude-code-security-review](https://github.com/anthropics/claude-code-security-review) - AI security review GitHub Action (Official).
 - [trailofbits/skills](https://github.com/trailofbits/skills) - Trail of Bits security research and audit Skills.
 - [playwright-skill](https://github.com/lackeyjb/playwright-skill) - Playwright browser automation testing Skill.


### PR DESCRIPTION
## Add Skill
**Name**: rails-conventions
**Link**: https://github.com/ethos-link/rails-conventions
**Description**: Rails 8.x conventions + implementation/review guidance for production apps.
**Category**: Development Tools

## Checklist
- [x] Link works
- [x] Includes SKILL.md
- [x] Description accurate
- [x] Added to correct category