### PR TITLE
Add cognyai/claude-code-marketing-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Skills work across multiple platforms:
 - [claude-skills](https://github.com/alirezarezvani/claude-skills) - 20+ productivity tools with 8 expert Agents.
 - [claude-code-skill-factory](https://github.com/alirezarezvani/claude-code-skill-factory) - Skills factory for batch generation and deployment.
 - [obra/superpowers](https://github.com/obra/superpowers) - Complete dev workflow (Debug/TDD/Code Review/Planning).
+- [cognyai/claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) - AI Marketing Skills (SEO Audit/Landing Page Review/Competitor Analysis/Ad Copy/Lead Qualification). 5 free + premium via Cogny MCP.
 - [coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills) - Marketing Skills (SEO/Copywriting/CRO/Ads).
 - [gingiris-launch](https://github.com/Gingiris/gingiris-launch) - Product Hunt launch playbook for AI products, startups, and open source GTM.
 - [gingiris-opensource](https://github.com/Gingiris/gingiris-opensource) - Open source marketing playbook focused on GitHub growth and launch strategy.


### PR DESCRIPTION
## Summary
- Adds [cognyai/claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) to Productivity section
- AI marketing skills: SEO Audit, Landing Page Review, Competitor Analysis, Ad Copy Writer, Lead Qualification
- 5 free skills (no account needed) + premium skills via Cogny MCP servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)