### PR TITLE
feat: add BytesAgain to Skills Collections (fix #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ English | [简体中文](README_ZH.md)
 
 ## Contents
 
-- [BytesAgain](https://bytesagain.com) - Search 60,000+ AI agent skills via MCP SSE or REST API. 7 languages. Free. https://bytesagain.com/mcp
 - [Quick Start](#quick-start)
 - [What Are Agent Skills](#what-are-agent-skills)
 - [Official Resources](#official-resources)
@@ -112,6 +111,7 @@ Skills work across multiple platforms:
 - [claude-code-kit](https://github.com/blencorp/claude-code-kit) - Claude Code toolkit with auto-activating skills.
 - [best-skills](https://github.com/xstongxue/best-skills) - High-quality Skills collection for paper writing, dev workflow, and content creation.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
+- [BytesAgain](https://bytesagain.com) - Search and discover 60,000+ AI agent skills across ClawHub, LobeHub, Dify, GitHub and more. Supports MCP SSE/REST API for agent integration. Free.
 
 ## Development Tools
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ English | [简体中文](README_ZH.md)
 
 ## Contents
 
+- [BytesAgain](https://bytesagain.com) - Search 60,000+ AI agent skills via MCP SSE or REST API. 7 languages. Free. https://bytesagain.com/mcp
 - [Quick Start](#quick-start)
 - [What Are Agent Skills](#what-are-agent-skills)
 - [Official Resources](#official-resources)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -169,6 +169,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | claude-code-kit | Claude Code 工具包，自动激活 skills | 82 | [GitHub](https://github.com/blencorp/claude-code-kit) |
 | best-skills | 通用高质量 Skills 合集，涵盖论文写作、开发流程、自媒体创作等 | 264 | [GitHub](https://github.com/xstongxue/best-skills) |
 | Skywork-Skills | Skywork 官方维护的 agent skills，面向 AI 办公场景，覆盖 PPT、文档、Excel、设计、搜索和音乐工作流 | 48 | [GitHub](https://github.com/SkyworkAI/Skywork-Skills) |
+| BytesAgain | 搜索和发现 60,000+ AI agent skills，覆盖 ClawHub、LobeHub、Dify、GitHub 等多个平台。支持 MCP SSE/REST API 接入，免费使用。 | — | [Website](https://bytesagain.com) |
 
 ## 开发工具
 


### PR DESCRIPTION
## What this PR does

Adds BytesAgain to the **Skills Collections** section (the correct location).

Changes:
- `README.md`: Added BytesAgain entry in Skills Collections section
- `README_ZH.md`: Added BytesAgain row in Skills 合集 table (in sync with README.md)

This is a corrected version of #25, which incorrectly placed the entry in the Contents section and didn't update README_ZH.md.

BytesAgain is a skill search platform that indexes 60,000+ AI agent skills from ClawHub, LobeHub, Dify, GitHub and more, with MCP SSE/REST API support.