### PR TITLE
✨ Add KubeStellar Console to DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Skills work across multiple platforms:
 - [devops-claude-skills](https://github.com/ahmedasmar/devops-claude-skills) - DevOps workflow marketplace with Terraform/K8s.
 - [claudekit-skills](https://github.com/mrgoonie/claudekit-skills) - Docker/GCP/Cloudflare deployment and management.
 - [claudebox](https://github.com/RchGrav/claudebox) - Dockerized Claude Code dev environment.
+- [kubestellar-console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with built-in MCP server for AI-assisted cluster operations, RBAC, and compliance.
 
 ## Data Processing
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -223,6 +223,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | ci-cd | CI/CD 管道设计、优化和安全扫描 | Claude | [claude-plugins.dev](https://claude-plugins.dev/skills/@ahmedasmar/devops-claude-skills/ci-cd) |
 | claudekit-skills | Docker/GCP/Cloudflare 部署和管理 | Claude | [GitHub](https://github.com/mrgoonie/claudekit-skills) |
 | claudebox | Docker 容器化 Claude Code 开发环境 | Claude | [GitHub](https://github.com/RchGrav/claudebox) |
+| kubestellar-console | 多集群 Kubernetes 仪表盘，内置 MCP 服务器，支持 AI 辅助集群运维、RBAC 和合规 | Claude, Copilot | [GitHub](https://github.com/kubestellar/console) |
 
 ## 数据处理
 


### PR DESCRIPTION
## What

Add [KubeStellar Console](https://github.com/kubestellar/console) to the DevOps section.

## Why

KubeStellar Console is a multi-cluster Kubernetes dashboard with a built-in MCP server (`kc-agent`) that enables AI coding agents (Claude Code, Copilot, Cursor) to manage workloads, policies, RBAC, and compliance across clusters. It's a CNCF Sandbox project with 50+ dashboard cards, real-time WebSocket streaming, and integrations with Argo, Kyverno, Istio, and 20+ CNCF projects.

## Changes

- Added entry to `README.md` (English)
- Added entry to `README_ZH.md` (Chinese)

Follows the existing format in both files.