### PR TITLE
Add buyer-eval-skill to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Skills work across multiple platforms:
 - [gingiris-opensource](https://github.com/Gingiris/gingiris-opensource) - Open source marketing playbook focused on GitHub growth and launch strategy.
 - [gingiris-b2b-growth](https://github.com/Gingiris/gingiris-b2b-growth) - B2B SaaS growth playbook covering PLG, SLG, and go-to-market strategy.
 - [gingiris-aso-growth](https://github.com/Gingiris/gingiris-aso-growth) - ASO and mobile app growth playbook for cold start, UGC, and distribution.
-- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation: domain-expert questions per software category, vendor AI agent conversations, evidence-tracked scoring across 7 dimensions, and comparative scorecards for procurement and build-vs-buy decisions.
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring and evidence-tracked scorecards for procurement and build-vs-buy decisions.
 
 ## DevOps
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Skills work across multiple platforms:
 - [gingiris-opensource](https://github.com/Gingiris/gingiris-opensource) - Open source marketing playbook focused on GitHub growth and launch strategy.
 - [gingiris-b2b-growth](https://github.com/Gingiris/gingiris-b2b-growth) - B2B SaaS growth playbook covering PLG, SLG, and go-to-market strategy.
 - [gingiris-aso-growth](https://github.com/Gingiris/gingiris-aso-growth) - ASO and mobile app growth playbook for cold start, UGC, and distribution.
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation: domain-expert questions per software category, vendor AI agent conversations, evidence-tracked scoring across 7 dimensions, and comparative scorecards for procurement and build-vs-buy decisions.
 
 ## DevOps
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -212,6 +212,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | gingiris-opensource | 面向 GitHub 增长与开源发布策略的营销 Playbook | All | [GitHub](https://github.com/Gingiris/gingiris-opensource) |
 | gingiris-b2b-growth | 覆盖 PLG、SLG 与 GTM 策略的 B2B SaaS 增长 Playbook | All | [GitHub](https://github.com/Gingiris/gingiris-b2b-growth) |
 | gingiris-aso-growth | 面向冷启动、UGC 与分发策略的 ASO 与移动增长 Playbook | All | [GitHub](https://github.com/Gingiris/gingiris-aso-growth) |
+| salespeak-ai/buyer-eval-skill | 结构化 B2B 软件供应商评估：7 维度评分与证据追踪的评分卡，用于采购与自建/采购决策 | All | [GitHub](https://github.com/salespeak-ai/buyer-eval-skill) |
 | changelog-generator | 从 Git 提交自动生成 Changelog | Claude | [ComposioHQ](https://github.com/ComposioHQ/awesome-claude-skills) |
 
 ## DevOps


### PR DESCRIPTION
Adds [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) to the **Productivity** section.

**What it is**: Structured, evidence-based B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions.

**License**: MIT

**Install**:
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

Fits the Productivity section alongside the gingiris growth playbooks and the marketing/SEO entries — it's the buy-side counterpart (procurement, RFP evaluation, build-vs-buy decisions).