### PR TITLE
Add ai-investment-skills to Data Processing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills work across multiple platforms:
 
 - [d3-visualization](https://github.com/ComposioHQ/awesome-claude-skills#data-visualization) - D3.js data visualization Skill.
 - [context-engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - Context engineering and multi-Agent architecture.
+- [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Six investment analysis skills: options flow scanner, stop-loss monitor, earnings risk check, sector rotation signal, and real-vs-lottery position classifier. Free tier included.
 
 ## Writing
 


### PR DESCRIPTION
## What this adds

Adds [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) to the **Data Processing** section.

Six investment analysis skills for Claude Code, Cursor, and Codex CLI:

- Options flow scanner with lottery-call filtering (delta <0.15 filter — caught CEG P/C anomaly: raw 1.06 → adjusted 59.2)
- Stop-loss & take-profit monitor with Telegram alerts (pre-market, regular, after-hours)
- Earnings risk check and IV crush detection
- Sector rotation signal via ETF options flow
- Real-vs-lottery position classifier

Free tier included in the repo.

```bash
cp options-flow-analyzer/SKILL.md ~/.claude/skills/options-flow-analyzer.md
```