### PR TITLE
Add Bilig WorkPaper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills work across multiple platforms:
 
 ## Data Processing
 
+- [bilig-workpaper](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper) - Formula-backed WorkPaper skill for editing cells, recalculating, verifying readback, and persisting spreadsheet logic from agents.
 - [d3-visualization](https://github.com/ComposioHQ/awesome-claude-skills#data-visualization) - D3.js data visualization Skill.
 - [context-engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - Context engineering and multi-Agent architecture.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -231,6 +231,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 
 | 名称 | 描述 | 平台 | 链接 |
 |------|------|------|------|
+| bilig-workpaper | 公式驱动的 WorkPaper Skill，可让 Agent 编辑单元格、重新计算、校验回读并持久化表格业务逻辑 | All | [GitHub](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper) |
 | d3-visualization | D3.js 数据可视化 Skill | Claude | [ComposioHQ](https://github.com/ComposioHQ/awesome-claude-skills) |
 | context-engineering | 上下文工程和多 Agent 架构 Skills | All | [GitHub](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) |
 


### PR DESCRIPTION
## Summary
- Adds Bilig WorkPaper to the Data Processing section.
- Updates both English and Chinese READMEs.

## Why
Bilig exposes a SKILL.md-backed WorkPaper workflow for agents to edit formula-backed workbook JSON, recalculate, verify readback, and persist state without an Excel UI.

## Checklist
- [x] Public GitHub link
- [x] Repository has 20+ stars
- [x] README.md and README_ZH.md updated
- [x] Existing category used