### PR TITLE
Add unifapi-agent/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skills work across multiple platforms:
 - [best-skills](https://github.com/xstongxue/best-skills) - High-quality Skills collection for paper writing, dev workflow, and content creation.
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
+- [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 
 ## Development Tools
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -173,6 +173,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | best-skills | 通用高质量 Skills 合集，涵盖论文写作、开发流程、自媒体创作等 | 264 | [GitHub](https://github.com/xstongxue/best-skills) |
 | skillkit | 跨平台 Skills 管理器，可安装、转换并同步 Skills 到 40+ Agent | 875 | [GitHub](https://github.com/rohitg00/skillkit) |
 | Skywork-Skills | Skywork 官方维护的 agent skills，面向 AI 办公场景，覆盖 PPT、文档、Excel、设计、搜索和音乐工作流 | 48 | [GitHub](https://github.com/SkyworkAI/Skywork-Skills) |
+| unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
 
 ## 开发工具
 


### PR DESCRIPTION
## Add Entry

**Name**: unifapi-agent/skills
**Link**: https://github.com/unifapi-agent/skills
**Description**: Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
**Category**: Skills Collections / Skills 合集
**Type**: Skills Collection

## Checklist

- [x] Link is valid
- [x] Updated both README.md and README_ZH.md
- [x] Description is accurate
- [x] Placed in correct category
- [x] Did not create a standalone section for a single project
- [x] Skills collection clearly serves the skills ecosystem
- [x] Repository meets the minimum threshold (20+ Stars for community projects)

## Validation

- `git diff --check`
- Verified https://github.com/unifapi-agent/skills returns 200