### PR TITLE
Add RunAPI CLI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Skills work across multiple platforms:
 - [Expo Skills](https://github.com/expo/skills) - Expo/React Native development Skills.
 - [browser-use/browser-use](https://github.com/browser-use/browser-use) - Browser automation Skill.
 - [Xquik x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X (Twitter) data Skill with REST endpoints, MCP tools, webhooks, SDKs, and automation workflows.
+- [runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill) - Generate AI images, videos, music/audio, and other model API jobs with the RunAPI CLI.
 - [code-review](https://github.com/JackyST0/awesome-agent-skills/tree/main/examples/code-review) - Smart code review example Skill.
 - [git-commit](https://github.com/JackyST0/awesome-agent-skills/tree/main/examples/git-commit) - Git commit message generator Skill.
 - [unit-test-generator](https://github.com/JackyST0/awesome-agent-skills/tree/main/examples/unit-test-generator) - Unit test auto-generator Skill.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -200,6 +200,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | expo/skills | ⭐ Expo/React Native 开发 Skills（931 ⭐） | All | [GitHub](https://github.com/expo/skills) |
 | browser-use/browser-use | 浏览器自动化 Skill（78.1k ⭐） | All | [GitHub](https://github.com/browser-use/browser-use) |
 | Xquik x-twitter-scraper | X（Twitter）数据平台 Skill，提供 REST API、MCP 工具、webhooks、SDK 和自动化工作流（66 ⭐） | All | [GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
+| runapi-ai/cli-skill | 用 RunAPI CLI 生成 AI 图片、视频、音乐/音频，并执行其他模型 API 任务 | All | [GitHub](https://github.com/runapi-ai/cli-skill) |
 | code-review | 智能代码审查示例 Skill | All | [示例](examples/code-review/) |
 | git-commit | Git 提交信息生成示例 Skill | All | [示例](examples/git-commit/) |
 | unit-test-generator | 单元测试自动生成 Skill | All | [示例](examples/unit-test-generator/) |

--- a/docs/skills.json
+++ b/docs/skills.json
@@ -500,6 +500,16 @@
     "url": "https://github.com/Xquik-dev/x-twitter-scraper"
   },
   {
+    "name": "runapi-ai/cli-skill",
+    "nameZh": "runapi-ai/cli-skill",
+    "desc": "用 RunAPI CLI 生成 AI 图片、视频、音乐/音频，并执行其他模型 API 任务",
+    "descEn": "Generate AI images, videos, music/audio, and other model API jobs with the RunAPI CLI",
+    "stars": "-",
+    "platform": "all",
+    "category": "devtools",
+    "url": "https://github.com/runapi-ai/cli-skill"
+  },
+  {
     "name": "code-review",
     "nameZh": "code-review",
     "desc": "Smart code review example Skill",


### PR DESCRIPTION
Adds runapi-ai/cli-skill under Development Tools, with the matching Chinese README entry and search metadata.
