### PR TITLE
Add CreatorSkills marketplace to Official Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Skills work across multiple platforms:
 - [Skills Leaderboard](https://skills.sh) - Open Agent Skills ecosystem directory.
 - [Tencent SkillHub](https://skillhub.tencent.com/) - Tencent's Skills community with 13k+ skills, optimized for Chinese users.
 - [ClawHub](https://docs.openclaw.ai/skills) - OpenClaw's public skills registry for discovering and sharing skills.
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth.
 
 ## Skills Collections
 


### PR DESCRIPTION
## What

Adds [CreatorSkills](https://creatorskills.co) to the **Official Resources** section alongside existing skill registries and directories (Skills Leaderboard, ClawHub, Agent Skills Index, Tencent SkillHub).

## Why

CreatorSkills is a marketplace of 30+ downloadable AI skills for content creators built on the SKILL.md open standard. It fits naturally next to the other external skill registries and discovery platforms already listed here.

## Entry added

```
- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth.
```