### PR TITLE
feat: add NotFair (Claude Code skills for SEO, Google Ads & Meta Ads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Skills work across multiple platforms:
 - [obra/superpowers](https://github.com/obra/superpowers) - Complete dev workflow (Debug/TDD/Code Review/Planning).
 - [cognyai/claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) - AI marketing skills (SEO Audit/Landing Page Review/Competitor Analysis/Ad Copywriting/Lead Qualification) with MCP server integration.
 - [coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills) - Marketing Skills (SEO/Copywriting/CRO/Ads).
+- [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) - Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 - [gingiris-launch](https://github.com/Gingiris/gingiris-launch) - Product Hunt launch playbook for AI products, startups, and open source GTM.
 - [gingiris-opensource](https://github.com/Gingiris/gingiris-opensource) - Open source marketing playbook focused on GitHub growth and launch strategy.
 - [gingiris-b2b-growth](https://github.com/Gingiris/gingiris-b2b-growth) - B2B SaaS growth playbook covering PLG, SLG, and go-to-market strategy.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -218,6 +218,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | obra/superpowers | ⭐ 完整开发工作流（调试/TDD/代码审查/计划）（48.8k ⭐） | All | [GitHub](https://github.com/obra/superpowers) |
 | cognyai/claude-code-marketing-skills | AI 营销技能（SEO 审计/落地页评审/竞品分析/广告文案/线索筛选），支持 MCP 服务器集成 | All | [GitHub](https://github.com/cognyai/claude-code-marketing-skills) |
 | coreyhaines31/marketingskills | ⭐ 营销 Skills（SEO/文案/CRO/广告）（7.1k ⭐） | All | [GitHub](https://github.com/coreyhaines31/marketingskills) |
+| nowork-studio/NotFair | Claude Code SEO、GEO、Google Ads 和 Meta Ads 技能集；通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 接入实时数据 | Claude | [GitHub](https://github.com/nowork-studio/NotFair) |
 | gingiris-launch | AI 产品、创业公司与开源项目的 Product Hunt 发布与 GTM 指南 | All | [GitHub](https://github.com/Gingiris/gingiris-launch) |
 | gingiris-opensource | 面向 GitHub 增长与开源发布策略的营销 Playbook | All | [GitHub](https://github.com/Gingiris/gingiris-opensource) |
 | gingiris-b2b-growth | 覆盖 PLG、SLG 与 GTM 策略的 B2B SaaS 增长 Playbook | All | [GitHub](https://github.com/Gingiris/gingiris-b2b-growth) |


### PR DESCRIPTION
## Add Entry

**Name**: nowork-studio/NotFair
**Link**: https://github.com/nowork-studio/NotFair
**Description**: Claude Code skills for SEO, GEO, Google Ads, and Meta Ads — connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
**Category**: Productivity
**Type**: Skills Collection

## About this addition

Thanks for maintaining this list — it's a great resource.

NotFair is an open-source collection of Claude Code skills (~2.9k stars, MIT license) for marketing practitioners. It covers SEO site audits, keyword research, meta-tag optimization, schema markup, and GEO optimization on the SEO side, plus wasted-spend detection, search-term cleanup, and bid management for Google Ads, and ROAS analysis, creative fatigue checks, and audience-overlap reviews for Meta Ads. All skills connect to live account data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

I placed it in the Productivity section alongside the other marketing-focused entries (`cognyai/claude-code-marketing-skills`, `coreyhaines31/marketingskills`). Happy to reword, move to a different category, or trim the description to better match the list's style.

## Checklist

- [x] Link is valid
- [x] Updated both README.md and README_ZH.md
- [x] Description is accurate
- [x] Placed in correct category
- [x] Did not create a standalone section for a single project
- [x] Skills collections / managers / installers clearly serve the skills ecosystem
- [x] Repository meets the minimum threshold (64+ Stars for community projects)