### PR TITLE
Add youtube-skills to Skills Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills work across multiple platforms:
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
+- [youtube-skills](https://github.com/sergebulaev/youtube-skills) - Claude Code and Codex skills for YouTube and Shorts: high-CTR titles, SEO descriptions, retention hooks, thumbnail briefs, and a content planner.
 
 ## Development Tools
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -179,6 +179,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | skillkit | 跨平台 Skills 管理器，可安装、转换并同步 Skills 到 40+ Agent | 875 | [GitHub](https://github.com/rohitg00/skillkit) |
 | Skywork-Skills | Skywork 官方维护的 agent skills，面向 AI 办公场景，覆盖 PPT、文档、Excel、设计、搜索和音乐工作流 | 48 | [GitHub](https://github.com/SkyworkAI/Skywork-Skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
+| youtube-skills | 面向 YouTube 和 Shorts 的 Claude Code 与 Codex Skills：高点击率标题、SEO 描述、留存钩子、缩略图简报与内容规划 | 2 | [GitHub](https://github.com/sergebulaev/youtube-skills) |
 
 ## 开发工具
 


### PR DESCRIPTION
## Add entry

**Name**: youtube-skills
**Link**: https://github.com/sergebulaev/youtube-skills
**Description**: 6 Claude Code and Codex skills for YouTube and YouTube Shorts marketing: high-CTR titles, SEO descriptions, retention hooks, thumbnail briefs, and a content planner. Installs with `/plugin marketplace add sergebulaev/youtube-skills`. MIT licensed.
**Category**: Skills Collections
**Type**: Skills collection (Claude Code + Codex plugin bundle)

## Checklist

- [x] Link is valid and publicly accessible
- [x] Updated both README.md and README_ZH.md (bilingual sync)
- [x] Placed in the correct existing category (no new section)
- [x] Followed the neighbor entry format
- [ ] 64+ stars: this is a newly published bundle (currently 2 stars). Flagging honestly for maintainer review; there is precedent for legitimate collections below the default bar. Feel free to decline if it does not meet the current inclusion threshold.

Minimal diff: one entry added per list file, nothing else changed.