### PR TITLE
Add harmony-next.skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Skills work across multiple platforms:
 - [debug-helper](https://github.com/JackyST0/awesome-agent-skills/tree/main/examples/debug-helper) - Code debugging assistant Skill.
 - [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents with encrypted local vault storage and proxy-based credential injection.
 - [Sverklo](https://github.com/sverklo/sverklo) - Local-first repo-memory MCP for coding agents: proof receipts, symbol refs, impact, and diff review.
+- [harmony-next.skills](https://github.com/linhay/harmony-next.skills) - HarmonyOS NEXT development workflows, offline references, DevEco/HDC automation, UI/UX audits, and smoke-test templates.
 
 ## Productivity
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -207,6 +207,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | debug-helper | 代码调试助手 Skill | All | [示例](examples/debug-helper/) |
 | authsome | AI Agent 本地凭据代理，加密本地保管库与基于代理的凭据注入 | All | [GitHub](https://github.com/agentrhq/authsome) |
 | Sverklo | 本地优先的仓库记忆 MCP，支持证明回执、符号引用、影响分析与差异审查 | All | [GitHub](https://github.com/sverklo/sverklo) |
+| harmony-next.skills | HarmonyOS NEXT 开发工作流、离线参考、DevEco/HDC 自动化、UI/UX 审计和 smoke-test 模板 | Codex/Claude/Cursor | [GitHub](https://github.com/linhay/harmony-next.skills) |
 
 ## 效率提升
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -207,7 +207,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | debug-helper | 代码调试助手 Skill | All | [示例](examples/debug-helper/) |
 | authsome | AI Agent 本地凭据代理，加密本地保管库与基于代理的凭据注入 | All | [GitHub](https://github.com/agentrhq/authsome) |
 | Sverklo | 本地优先的仓库记忆 MCP，支持证明回执、符号引用、影响分析与差异审查 | All | [GitHub](https://github.com/sverklo/sverklo) |
-| harmony-next.skills | HarmonyOS NEXT 开发工作流、离线参考、DevEco/HDC 自动化、UI/UX 审计和 smoke-test 模板 | Codex/Claude/Cursor | [GitHub](https://github.com/linhay/harmony-next.skills) |
+| harmony-next.skills | HarmonyOS NEXT 开发工作流、离线参考、DevEco/HDC 自动化、UI/UX 审计和 smoke-test 模板 | Claude/Codex/Cursor | [GitHub](https://github.com/linhay/harmony-next.skills) |
 
 ## 效率提升
 


### PR DESCRIPTION
## Resource

- Name: harmony-next.skills
- URL: https://github.com/linhay/harmony-next.skills
- Category: Development Tools

## Why it fits

This repository provides a production-oriented HarmonyOS NEXT skill for AI coding agents. It gives agents local references and executable workflows for ArkTS/ArkUI/API lookup, DevEco Studio, HDC, Emulator launch diagnostics, UI/UX audits, and smoke-test scaffolding.