### PR TITLE
Add nika-skills to DevOps (README + README_ZH in sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Skills work across multiple platforms:
 - [devops-claude-skills](https://github.com/ahmedasmar/devops-claude-skills) - DevOps workflow marketplace with Terraform/K8s.
 - [claudekit-skills](https://github.com/mrgoonie/claudekit-skills) - Docker/GCP/Cloudflare deployment and management.
 - [claudebox](https://github.com/RchGrav/claudebox) - Dockerized Claude Code dev environment.
+- [nika-skills](https://github.com/supernovae-st/nika-agents) - Author checked .nika.yaml AI workflows: statically audited before a token is spent, tamper-evident traces after.
 
 ## Data Processing
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -236,6 +236,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | ci-cd | CI/CD 管道设计、优化和安全扫描 | Claude | [claude-plugins.dev](https://claude-plugins.dev/skills/@ahmedasmar/devops-claude-skills/ci-cd) |
 | claudekit-skills | Docker/GCP/Cloudflare 部署和管理 | Claude | [GitHub](https://github.com/mrgoonie/claudekit-skills) |
 | claudebox | Docker 容器化 Claude Code 开发环境 | Claude | [GitHub](https://github.com/RchGrav/claudebox) |
+| nika-skills | 编写可校验的 .nika.yaml AI 工作流：花费 token 前静态审计，运行后留下防篡改追踪 | All | [GitHub](https://github.com/supernovae-st/nika-agents) |
 
 ## 数据处理
 


### PR DESCRIPTION
Disclosure: I maintain nika (github.com/supernovae-st/nika), an open-source AGPL-3.0 project. Per CONTRIBUTING: both README.md and README_ZH.md updated in the same move (bilingual sync), entry format matched (EN bullet + ZH 4-column table row), placed in **DevOps**.

**[nika-skills](https://github.com/supernovae-st/nika-agents)** teaches an agent to author `.nika.yaml` AI workflows that are statically audited before a token is spent (`nika check`: plan, honest cost floor, secret flows, default-deny permits) and leave tamper-evident hash-chained traces after. Platform column says **All** honestly: the pack ships for Claude Code, Codex, Hermes and OpenCode.

Publicly accessible, links valid, maintained (engine at 0.99, pushed daily). Verify in two commands, offline, zero keys: `brew install supernovae-st/tap/nika` then `nika examples run 01-hello --model mock/echo`. Happy to adjust wording or placement.