### PR TITLE
feat: add markstream-install skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Skills work across multiple platforms:
 - [trailofbits/skills](https://github.com/trailofbits/skills) - Trail of Bits security research and audit Skills.
 - [playwright-skill](https://github.com/lackeyjb/playwright-skill) - Playwright browser automation testing Skill.
 - [gh-code-review](https://github.com/bkircher/skills) - PR code review Skill for GitHub.
+- [markstream-install](https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills/markstream-install) - Install streaming Markdown renderers across Vue, React, Svelte, Angular, and Vue 2 projects.
 - [skill-codex](https://github.com/skills-directory/skill-codex) - Delegate tasks to Codex Skill.
 - [claude-code-skills](https://github.com/daymade/claude-code-skills) - Professional Skills marketplace.
 - [skillset-example](https://github.com/copilot-extensions/skillset-example) - GitHub Copilot extension example.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -190,6 +190,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | trailofbits/skills | ⭐ Trail of Bits 安全研究和审计 Skills | Claude | [GitHub](https://github.com/trailofbits/skills) |
 | playwright-skill | Playwright 浏览器自动化测试 Skill | Claude | [GitHub](https://github.com/lackeyjb/playwright-skill) |
 | gh-code-review | GitHub PR 代码审查 Skill | Copilot | [GitHub](https://github.com/bkircher/skills) |
+| markstream-install | 为 Vue、React、Svelte、Angular 和 Vue 2 项目安装流式 Markdown 渲染器 | All | [GitHub](https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills/markstream-install) |
 | skill-codex | 将任务委派给 Codex 的 Skill | Claude | [GitHub](https://github.com/skills-directory/skill-codex) |
 | skillset-example | GitHub Copilot 扩展示例 | Copilot | [GitHub](https://github.com/copilot-extensions/skillset-example) |
 | claude-code-skills | 专业级 Skills 市场 | Claude | [GitHub](https://github.com/daymade/claude-code-skills) |


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: `markstream-install`  
**链接 / Link**: https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills/markstream-install  
**描述 / Description**: 为 Vue、React、Svelte、Angular 和 Vue 2 项目安装流式 Markdown 渲染器的 Skill。 / A Skill for installing streaming Markdown renderers in Vue, React, Svelte, Angular, and Vue 2 projects.  
**分类 / Category**: 开发工具 / Development Tools  
**类型 / Type**: Single Skill

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate
- [x] 放在正确分类 / Placed in correct category
- [x] 没有为单个项目新增独立 section / Did not create a standalone section for a single project
- [ ] 按字母顺序排列 / Sorted alphabetically
- [x] 单个 Skill 仓库包含 SKILL.md（如适用） / Single Skill repository contains SKILL.md (if applicable)
- [ ] Skills 合集 / 管理器 / 安装器明确服务于 Skills 生态（如适用） / Skills collection / manager / installer clearly serves the skills ecosystem (if applicable)
- [x] 社区项目满足最低门槛（64+ Stars，如适用） / Community project meets the minimum threshold (64+ Stars, if applicable)

## 其他说明 / Additional Notes

开发工具现有列表并非按字母顺序排列，因此本条目放在相近的开发工具 Skills 附近。 / The existing Development Tools list is not alphabetically ordered, so this entry is placed next to comparable development-tool Skills.
