### PR TITLE
Add fractal to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills work across multiple platforms:
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/blob/master/skills/agenttrace-session-audit/SKILL.md) - Audit local AI coding-agent session health, cost, failures, and diffs.
 - [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) - Production-grade engineering skills and slash-command workflows for AI coding agents.
 - [claude-code-security-review](https://github.com/anthropics/claude-code-security-review) - AI security review GitHub Action (Official).
+- [fractal](https://github.com/plasma-ai/fractal/blob/main/fractal/skills/fractal/SKILL.md) - Run bounded hierarchical coding-agent loops with recursive delegation and isolated Git worktrees.
 - [trailofbits/skills](https://github.com/trailofbits/skills) - Trail of Bits security research and audit Skills.
 - [playwright-skill](https://github.com/lackeyjb/playwright-skill) - Playwright browser automation testing Skill.
 - [gh-code-review](https://github.com/bkircher/skills) - PR code review Skill for GitHub.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -187,6 +187,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | agenttrace-session-audit | 审计本地 AI 编程 Agent 会话的健康度、成本、失败与差异 | All | [GitHub](https://github.com/luoyuctl/agenttrace/blob/master/skills/agenttrace-session-audit/SKILL.md) |
 | addyosmani/agent-skills | 面向 AI 编程代理的生产级工程技能与斜杠命令工作流 | All | [GitHub](https://github.com/addyosmani/agent-skills) |
 | claude-code-security-review | ⭐ AI 安全审查 GitHub Action（官方） | Claude | [GitHub](https://github.com/anthropics/claude-code-security-review) |
+| fractal | 运行有界分层编程 Agent 循环，支持递归委派与隔离 Git worktree | Claude/Codex/OpenCode | [GitHub](https://github.com/plasma-ai/fractal/blob/main/fractal/skills/fractal/SKILL.md) |
 | trailofbits/skills | ⭐ Trail of Bits 安全研究和审计 Skills | Claude | [GitHub](https://github.com/trailofbits/skills) |
 | playwright-skill | Playwright 浏览器自动化测试 Skill | Claude | [GitHub](https://github.com/lackeyjb/playwright-skill) |
 | gh-code-review | GitHub PR 代码审查 Skill | Copilot | [GitHub](https://github.com/bkircher/skills) |


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: fractal
**链接 / Link**: https://github.com/plasma-ai/fractal/blob/main/fractal/skills/fractal/SKILL.md
**描述 / Description**: Run bounded hierarchical coding-agent loops with recursive delegation and isolated Git worktrees. / 运行有界分层编程 Agent 循环，支持递归委派与隔离 Git worktree。
**分类 / Category**: Development Tools / 开发工具
**类型 / Type**: Single Skill

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate
- [x] 放在正确分类 / Placed in correct category
- [x] 没有为单个项目新增独立 section / Did not create a standalone section for a single project
- [x] 按字母顺序排列 / Sorted alphabetically
- [x] 单个 Skill 仓库包含 SKILL.md（如适用） / Single Skill repository contains SKILL.md (if applicable)
- [x] Skills 合集 / 管理器 / 安装器明确服务于 Skills 生态（如适用） / Skills collection / manager / installer clearly serves the skills ecosystem (if applicable)
- [x] 社区项目满足最低门槛（64+ Stars，如适用） / Community project meets the minimum threshold (64+ Stars, if applicable)

## 其他说明 / Additional Notes

- The canonical skill supports Claude Code, Codex, and OpenCode workflows.
- The Apache-2.0 repository currently exceeds the 64-star community threshold.
- `git diff --check` passes.
- Per the repository template, `docs/skills.json` is left for automatic post-merge generation.

Disclosure: I am affiliated with Plasma AI, which maintains fractal.