### PR TITLE
Add wiki to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills work across multiple platforms:
 - [gingiris-aso-growth](https://github.com/Gingiris/gingiris-aso-growth) - ASO and mobile app growth playbook for cold start, UGC, and distribution.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Harness-enforced business research skill with consulting frameworks, evidence grading, stage gates, and HTML reports.
 - [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring and evidence-tracked scorecards for procurement and build-vs-buy decisions.
+- [wiki](https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md) - Build indexed Markdown knowledge bases that agents map, search, read, update, and lint.
 
 ## DevOps
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -227,6 +227,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | alpha-insights | 带 Harness 门控的商业研究 Skill，内置咨询框架、证据分级、阶段门控与 HTML 报告 | Claude/Codex | [GitHub](https://github.com/Ericyoung-183/alpha-insights) |
 | salespeak-ai/buyer-eval-skill | 结构化 B2B 软件供应商评估：7 维度评分与证据追踪的评分卡，用于采购与自建/采购决策 | All | [GitHub](https://github.com/salespeak-ai/buyer-eval-skill) |
 | changelog-generator | 从 Git 提交自动生成 Changelog | Claude | [ComposioHQ](https://github.com/ComposioHQ/awesome-claude-skills) |
+| wiki | 构建带索引的 Markdown 知识库，供 Agent 映射、搜索、读取、更新与检查 | Claude/Codex | [GitHub](https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md) |
 
 ## DevOps
 


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: wiki
**链接 / Link**: https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md
**描述 / Description**: Build indexed Markdown knowledge bases that agents map, search, read, update, and lint. / 构建带索引的 Markdown 知识库，供 Agent 映射、搜索、读取、更新与检查。
**分类 / Category**: Productivity / 效率提升
**类型 / Type**: Single Skill

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate
- [x] 放在正确分类 / Placed in correct category
- [x] 没有为单个项目新增独立 section / Did not create a standalone section for a single project
- [x] 按字母顺序排列 / Sorted alphabetically
- [x] 单个 Skill 仓库包含 SKILL.md（如适用） / Single Skill repository contains SKILL.md (if applicable)
- [x] Skills 合集 / 管理器 / 安装器明确服务于 Skills 生态（如适用） / Skills collection / manager / installer clearly serves the skills ecosystem (if applicable)
- [x] 社区项目满足最低门槛（64+ Stars，如适用） / Community project meets the minimum threshold (64+ Stars, if applicable)

## 其他说明 / Additional Notes

- The canonical skill supports Claude Code and Codex workflows.
- The Apache-2.0 repository currently exceeds the 64-star community-project threshold.
- `git diff --check` passes.
- `docs/skills.json` is intentionally left to automatic post-merge generation.

Disclosure: I am affiliated with Plasma AI.