### PR TITLE
Add OrkasVideoStudio skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills work across multiple platforms:
 - [claude-code-kit](https://github.com/blencorp/claude-code-kit) - Claude Code toolkit with auto-activating skills.
 - [best-skills](https://github.com/xstongxue/best-skills) - High-quality Skills collection for paper writing, dev workflow, and content creation.
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) - Agent video-production skill pack with CLI and MCP runtime.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -177,6 +177,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | claude-code-kit | Claude Code 工具包，自动激活 skills | 98 | [GitHub](https://github.com/blencorp/claude-code-kit) |
 | best-skills | 通用高质量 Skills 合集，涵盖论文写作、开发流程、自媒体创作等 | 264 | [GitHub](https://github.com/xstongxue/best-skills) |
 | skillkit | 跨平台 Skills 管理器，可安装、转换并同步 Skills 到 40+ Agent | 875 | [GitHub](https://github.com/rohitg00/skillkit) |
+| OrkasVideoStudio | 面向 Agent 的视频制作 Skills 合集，配套 CLI 与 MCP 运行时 | 515 | [GitHub](https://github.com/Orkas-AI/Orkas-VideoStudio) |
 | Skywork-Skills | Skywork 官方维护的 agent skills，面向 AI 办公场景，覆盖 PPT、文档、Excel、设计、搜索和音乐工作流 | 48 | [GitHub](https://github.com/SkyworkAI/Skywork-Skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
 


### PR DESCRIPTION
## Summary

Add OrkasVideoStudio to the Skills Collections section in both English and Chinese. It ships a host-neutral video-production skill pack with CLI and MCP runtimes for Codex, Claude Code, and other shell- or MCP-capable agents.

## Validation

- English and Chinese README files updated together
- public MIT repository with 515 stars at submission time
- contains multiple documented `SKILL.md` packages
- repository URL returns HTTP 200
- `git diff --check` passes

Disclosure: submitted on behalf of the OrkasVideoStudio project.