### PR TITLE
docs: add WeekLife

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills work across multiple platforms:
 - [gingiris-aso-growth](https://github.com/Gingiris/gingiris-aso-growth) - ASO and mobile app growth playbook for cold start, UGC, and distribution.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Harness-enforced business research skill with consulting frameworks, evidence grading, stage gates, and HTML reports.
 - [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring and evidence-tracked scorecards for procurement and build-vs-buy decisions.
+- [WeekLife](https://letmethink.cc/app/weeklife/) - A lightweight life check-in tool for reclaiming everyday life beyond work.
 
 ## DevOps
 


### PR DESCRIPTION
Hi! I'd like to suggest adding WeekLife to this list.

- [WeekLife](https://letmethink.cc/app/weeklife/) — A lightweight life check-in tool designed to help people reclaim their weekdays.

I reviewed the list and believe this project fit the selected section. Happy to adjust the wording or placement to match the maintainers' preference.

Thanks for maintaining this resource.