### PR TITLE
Add suede-creator-skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Skills work across multiple platforms:
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
 - [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) - Agent video-production skill pack with CLI and MCP runtime.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Skills pack for Claude Code and Codex covering code review and grading, design, marketing and SEO, agent workflows, and mobile app shipping.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 - [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcript, video search, channel and playlist skills for Claude Code, OpenClaw, Hermes Agent, and other agent runtimes.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -182,6 +182,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | skillkit | 跨平台 Skills 管理器，可安装、转换并同步 Skills 到 40+ Agent | 875 | [GitHub](https://github.com/rohitg00/skillkit) |
 | OrkasVideoStudio | 面向 Agent 的视频制作 Skills 合集，配套 CLI 与 MCP 运行时 | 515 | [GitHub](https://github.com/Orkas-AI/Orkas-VideoStudio) |
 | Skywork-Skills | Skywork 官方维护的 agent skills，面向 AI 办公场景，覆盖 PPT、文档、Excel、设计、搜索和音乐工作流 | 48 | [GitHub](https://github.com/SkyworkAI/Skywork-Skills) |
+| suede-creator-skills | 面向 Claude Code 与 Codex 的 Skills 合集，覆盖代码质量与评审、设计、营销与 SEO、Agent 工作流和移动应用发布 | 153 | [GitHub](https://github.com/JasonColapietro/suede-creator-skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
 | youtube-skills | 面向 YouTube 的转录、视频搜索、频道浏览与播放列表 Skills，适用于 Claude Code、OpenClaw、Hermes Agent 等 Agent 运行时 | 504 | [GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
 


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: suede-creator-skills
**链接 / Link**: https://github.com/JasonColapietro/suede-creator-skills
**描述 / Description**: Skills pack for Claude Code and Codex covering code review and grading, design, marketing and SEO, agent workflows, and mobile app shipping.
**分类 / Category**: Skills Collections / Skills 合集
**类型 / Type**: Skills Collection

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate
- [x] 放在正确分类 / Placed in correct category
- [x] 没有为单个项目新增独立 section / Did not create a standalone section for a single project
- [x] 按字母顺序排列 / Sorted alphabetically
- [x] Single Skill SKILL.md requirement is not applicable
- [x] Skills collection clearly serves the skills ecosystem
- [x] Repository meets the star threshold

## 其他说明 / Additional Notes

Both entries are now count-free, so they will not go stale as the collection grows. The star column in `README_ZH.md` is left for your `chore: update star counts` job to maintain. Rebased onto current `main`; the earlier conflict is resolved.
