### PR TITLE
Add awesome-seedance-2.5-prompts-skills to Skills Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills work across multiple platforms:
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
+- [awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) - 150+ curated Seedance 2.5 video prompts plus an installable Skill that refines prompts, plans storyboards, and generates video.
 
 ## Development Tools
 


### PR DESCRIPTION
Adds one entry to **Skills Collections**.

[awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) is a curated library of 150+ Seedance 2.5 video prompts that also ships an installable Agent Skill (`skills/seedance-2-5-skill`): it rewrites a rough idea into a model-ready prompt, plans a storyboard when the shot needs one, and generates the video. Works in Claude Code, Codex and other agents. 115 stars, CC BY 4.0, README available in 19 languages.

It fits this section rather than a single-skill one because the repo is a collection (prompt library + skill), same shape as the ComposioHQ / VoltAgent / hesreallyhim entries already listed here.

Disclosure: I work at Atlas Cloud, whose API the bundled skill calls by default; the prompt library itself is platform-agnostic.