### PR TITLE
Add auteur to Design / 设计相关

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Skills work across multiple platforms:
 - [theme-factory](https://github.com/anthropics/skills/tree/main/skills/theme-factory) - Theme style factory Skill.
 - [algorithmic-art](https://github.com/anthropics/skills/tree/main/skills/algorithmic-art) - Algorithmic art generation Skill.
 - [slack-gif-creator](https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator) - Slack GIF creator Skill.
+- [auteur](https://github.com/agiwhitelist/auteur) - Builds complete websites from a written art-direction commitment, gated by an anti-slop linter and motion QA.
 
 ## Contributing
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -267,6 +267,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | theme-factory | ⭐ 主题样式工厂 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/theme-factory) |
 | algorithmic-art | ⭐ 算法艺术生成 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/algorithmic-art) |
 | slack-gif-creator | ⭐ Slack GIF 创建 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator) |
+| auteur | 先写死美术方向再建站，由反 AI 味 linter 与动效 QA 把关 | Claude / 通用 | [GitHub](https://github.com/agiwhitelist/auteur) |
 
 ## Contributing
 


### PR DESCRIPTION
Adds `auteur` to the Design section, updating both `README.md` and `README_ZH.md` as CONTRIBUTING requires.

**Repo:** https://github.com/agiwhitelist/auteur — MIT, `SKILL.md` at repo root, docs in English and Chinese.

**What it does.** Art direction is committed to a written sheet — one brand hue, a type system, a motion budget, named anti-references — before any markup exists. Two runnable gates then decide whether the build ships:

- `slopscan` — zero-dependency linter that fails on concrete generic-design tells; suppressions need a written reason it validates itself
- `motionqa` — Playwright under 4x CPU throttle: FPS, long tasks, console errors, contrast

Ten live sites at https://agiwhitelist.github.io/auteur/ each pass both gates, and either script runs standalone against any URL, so the claim is reproducible rather than asserted.

**Platform column** is `Claude / 通用`: it installs natively into Claude Code and, via `npx skills add`, into any agent that reads a `SKILL.md`. The scripts run from a plain shell regardless of host.