### PR TITLE
Add agent-skill-manager: cross-platform skill manager for 9 Chinese AI agent products

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills work across multiple platforms:
 - [claude-code-kit](https://github.com/blencorp/claude-code-kit) - Claude Code toolkit with auto-activating skills.
 - [best-skills](https://github.com/xstongxue/best-skills) - High-quality Skills collection for paper writing, dev workflow, and content creation.
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
+- [agent-skill-manager](https://github.com/yxdwind/agent-skill-manager) - Cross-platform skill manager for 9 Chinese AI agent products (AutoClaw, Kimi, MiniMax, WorkBuddy, Trae, DuMate, CodeBuddy, Comate, Qoder).
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 


### PR DESCRIPTION
## 新增项目

[agent-skill-manager](https://github.com/yxdwind/agent-skill-manager) — Cross-platform (macOS/Windows) skill manager for 9 Chinese AI agent products.

### Supported Products (9)

AutoClaw, Kimi Code, MiniMax Code, WorkBuddy, Trae Solo, DuMate (Baidu), CodeBuddy (Tencent), Comate/Wenxin Kuaima (Baidu), Qoder/Tongyi Lingma (Alibaba)

### Key Features

- Central repo + symlink/junction distribution model
- Zero third-party dependencies (Python 3.8+ stdlib only)
- 34 tests passing
- CLI tool: \skill sync\ to distribute skills to all products at once

### Placement

Added in the Skills Managers section, alongside skillkit and other managers. Complements international-focused tools by covering Chinese domestic AI agent products.