### PR TITLE
Add youtube-skills to Skills Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills work across multiple platforms:
 - [skillkit](https://github.com/rohitg00/skillkit) - Cross-platform skills manager that installs, translates, and syncs skills across 40+ agents.
 - [Skywork-Skills](https://github.com/SkyworkAI/Skywork-Skills) - Officially maintained Skywork agent skills for AI office workflows, including PPT, documents, Excel, design, search, and music.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
+- [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcript, video search, channel and playlist skills for Claude Code, OpenClaw, Hermes Agent, and other agent runtimes.
 
 ## Development Tools
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -179,6 +179,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | skillkit | 跨平台 Skills 管理器，可安装、转换并同步 Skills 到 40+ Agent | 875 | [GitHub](https://github.com/rohitg00/skillkit) |
 | Skywork-Skills | Skywork 官方维护的 agent skills，面向 AI 办公场景，覆盖 PPT、文档、Excel、设计、搜索和音乐工作流 | 48 | [GitHub](https://github.com/SkyworkAI/Skywork-Skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
+| youtube-skills | 面向 YouTube 的转录、视频搜索、频道浏览与播放列表 Skills，适用于 Claude Code、OpenClaw、Hermes Agent 等 Agent 运行时 | 504 | [GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
 
 ## 开发工具
 


### PR DESCRIPTION
## Add Entry

**Name**: youtube-skills
**Link**: https://github.com/ZeroPointRepo/youtube-skills
**Description**: An MIT licensed collection of agent skills for YouTube transcripts, video search, channel browsing and playlist extraction, installable into Claude Code, OpenClaw, Hermes Agent and other agent runtimes.
**Category**: Skills Collections
**Type**: Skills Collection

The repo ships 12 skills under `skills/` (youtube-full, transcript, youtube-data, youtube-search, youtube-channels, youtube-playlist and others), each with its own `SKILL.md`. It currently has 504 GitHub Stars and is MIT licensed with the full source public.

Disclosure: I maintain ZeroPointRepo/youtube-skills.

## Checklist

- [x] Link is valid
- [x] Updated both README.md and README_ZH.md
- [x] Description is accurate
- [x] Placed in correct category
- [x] Did not create a standalone section for a single project
- [x] Alphabetically ordered (appended after `unifapi-agent/skills`, the last entry in the section)
- [x] Single Skill repository contains SKILL.md (each skill folder has one)
- [x] Skills collections / managers / installers clearly serve the skills ecosystem
- [x] Repository meets the minimum threshold (64+ Stars for community projects) — 504 stars
- [x] No manual edits to `docs/skills.json` (generated automatically after merge)

Minimal diff: one entry added per list file, nothing else changed.