### PR TITLE
docs: add Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Skills work across multiple platforms:
 
 ## Skills Collections
 
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Portable agent packages, orchestration, runtime adapters, A2A Agent Cards, and MCP integration for Claude Code, Codex, Gemini, Cursor, Antigravity, and local models.
 - [awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) - The most comprehensive Cursor Rules collection.
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) - Complete Claude Code configs (agents/skills/hooks).
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) - Community-curated Agent Skills directory focused on real-world skills used by engineering teams.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -162,6 +162,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 
 | 名称 | 描述 | Stars | 链接 |
 |------|------|-------|------|
+| Agentlas OS | 面向 Claude Code、Codex、Gemini、Cursor、Antigravity 和本地模型的可移植 Agent 软件包、编排、运行时适配器、A2A Agent Card 与 MCP 集成 | 1.1k | [GitHub](https://github.com/agentlas-ai/Agentlas-OS) |
 | awesome-cursorrules | ⭐ 最全面的 Cursor Rules 合集 | 40.5k | [GitHub](https://github.com/PatrickJS/awesome-cursorrules) |
 | everything-claude-code | ⭐ Claude Code 配置大全（agents/skills/hooks） | 185.6k | [GitHub](https://github.com/affaan-m/everything-claude-code) |
 | heilcheng/awesome-agent-skills | ⭐ 社区维护的 Agent Skills 导航，聚焦工程团队实际使用的真实 Skills | 5.3k | [GitHub](https://github.com/heilcheng/awesome-agent-skills) |


### PR DESCRIPTION
## Summary\n- Add Agentlas OS to Skills Collections in both language READMEs.\n- Link the canonical repository: https://github.com/agentlas-ai/Agentlas-OS\n\nAgentlas OS provides portable agent packages, orchestration, runtime adapters, A2A Agent Cards, and MCP integration for Claude Code, Codex, Gemini, Cursor, Antigravity, and local models.\n\nThis is a self-nomination. I maintain and contribute to Agentlas OS.\n\n## Scope\n- README.md and README_ZH.md only\n- Bilingual metadata points to the same canonical source\n- No copied skill files, scripts, generated indexes, or assets