### PR TITLE
Add comfortable-roadtrip-planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills work across multiple platforms:
 - [gingiris-aso-growth](https://github.com/Gingiris/gingiris-aso-growth) - ASO and mobile app growth playbook for cold start, UGC, and distribution.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Harness-enforced business research skill with consulting frameworks, evidence grading, stage gates, and HTML reports.
 - [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring and evidence-tracked scorecards for procurement and build-vs-buy decisions.
+- [comfortable-roadtrip-planner](https://github.com/CrazyRiceMaker/comfortable-roadtrip-planner) - Comfort-first road trip / 自驾路书 skill for Codex, Claude Code, Cursor, and OpenClaw. Keeps booked hotels fixed, ranks stops A/B/C for limited stamina, and outputs an interactive HTML route app with maps, meals, tickets, and calendar .ics.
 
 ## DevOps
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -226,6 +226,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | gingiris-aso-growth | 面向冷启动、UGC 与分发策略的 ASO 与移动增长 Playbook | All | [GitHub](https://github.com/Gingiris/gingiris-aso-growth) |
 | alpha-insights | 带 Harness 门控的商业研究 Skill，内置咨询框架、证据分级、阶段门控与 HTML 报告 | Claude/Codex | [GitHub](https://github.com/Ericyoung-183/alpha-insights) |
 | salespeak-ai/buyer-eval-skill | 结构化 B2B 软件供应商评估：7 维度评分与证据追踪的评分卡，用于采购与自建/采购决策 | All | [GitHub](https://github.com/salespeak-ai/buyer-eval-skill) |
+| comfortable-roadtrip-planner | 舒适优先的自驾路书 Skill：锁死已订酒店，按体力把景点标成 A/B/C，并产出带地图、吃饭、票务和日历导入的交互式 HTML 路线图 | All | [GitHub](https://github.com/CrazyRiceMaker/comfortable-roadtrip-planner) |
 | changelog-generator | 从 Git 提交自动生成 Changelog | Claude | [ComposioHQ](https://github.com/ComposioHQ/awesome-claude-skills) |
 
 ## DevOps


### PR DESCRIPTION
## Summary
Add [comfortable-roadtrip-planner](https://github.com/CrazyRiceMaker/comfortable-roadtrip-planner), an Agent Skill for Codex, Claude Code, Cursor, and OpenClaw.

It plans comfort-first multi-day self-drive trips around already-booked hotels and limited stamina, ranks stops A/B/C, and outputs a one-file interactive HTML route app (maps, meals, tickets, calendar .ics).

## Why it belongs here
- Public MIT skill with SKILL.md, evals, and a redacted golden HTML example
- Distinct from generic sightseeing dumps: hotels stay fixed, pacing is pregnancy/low-stamina aware
- Installable via git clone into standard skills directories

## Test plan
- [ ] Link resolves
- [ ] Description matches the repo

Made with [Cursor](https://cursor.com)