### PR TITLE
Add UIZZE anti-UI-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills work across multiple platforms:
 ## Design
 
 - [frontend-design](https://github.com/anthropics/skills/tree/main/skills/frontend-design) - Frontend UI design Skill.
+- [UIZZE](https://github.com/uizze/uizze) - Anti-UI-slop Skill and hard UI Slop Gate for coding agents, with a free MCP preview grounded in 800,000+ real web and iOS screens.
 - [brand-guidelines](https://github.com/anthropics/skills/tree/main/skills/brand-guidelines) - Brand design guidelines Skill.
 - [canvas-design](https://github.com/anthropics/skills/tree/main/skills/canvas-design) - Canvas design Skill.
 - [theme-factory](https://github.com/anthropics/skills/tree/main/skills/theme-factory) - Theme style factory Skill.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -262,6 +262,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | 名称 | 描述 | 平台 | 链接 |
 |------|------|------|------|
 | frontend-design | ⭐ 前端 UI 设计 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/frontend-design) |
+| UIZZE | 面向编程代理的 anti-UI-slop Skill 与 UI Slop Gate，提供基于 800,000+ 个真实 Web 与 iOS 界面的免费 MCP 预览 | All | [GitHub](https://github.com/uizze/uizze) |
 | brand-guidelines | ⭐ 品牌设计规范 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/brand-guidelines) |
 | canvas-design | ⭐ Canvas 画布设计 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/canvas-design) |
 | theme-factory | ⭐ 主题样式工厂 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/theme-factory) |


### PR DESCRIPTION
## Add Entry

**Name**: UIZZE
**Link**: https://github.com/uizze/uizze
**Description**: Anti-UI-slop Skill and hard UI Slop Gate for coding agents, with a free MCP preview grounded in 800,000+ real web and iOS screens.
**Category**: Design / 设计相关
**Type**: Single Skill

## Checklist

- [x] Link is valid
- [x] Updated both README.md and README_ZH.md
- [x] Description is accurate
- [x] Placed in the existing Design category
- [x] Public repository contains skills/anti-ui-slop/SKILL.md
- [x] UIZZE repository has more than the 64-star community threshold

The free skill runs locally; the preview MCP is optional and does not require an account or source upload. Canonical copy: https://github.com/uizze/uizze/blob/main/DISTRIBUTION.md