### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,4 +242,4 @@ PayPal: [paypal.me/JackyST0](https://paypal.me/JackyST0)
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JackyST0/awesome-agent-skills&type=Date)](https://star-history.com/#JackyST0/awesome-agent-skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JackyST0/awesome-agent-skills&type=Date)](https://star-history.dera.page/#JackyST0/awesome-agent-skills&Date)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -324,4 +324,4 @@ my-skill/
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JackyST0/awesome-agent-skills&type=Date)](https://star-history.com/#JackyST0/awesome-agent-skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JackyST0/awesome-agent-skills&type=Date)](https://star-history.dera.page/#JackyST0/awesome-agent-skills&Date)


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and does not render. This change points the chart to a working source in both the English and Chinese READMEs so visitors can see the project's star history again. No other behavior is affected.