### PR TITLE
Add Slashbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills work across multiple platforms:
 - [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring and evidence-tracked scorecards for procurement and build-vs-buy decisions.
 - [changelog-generator](https://github.com/ComposioHQ/awesome-claude-skills) - Generate changelogs from Git commits.
 - [wiki](https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md) - Build indexed Markdown knowledge bases that agents map, search, read, update, and lint.
+- [Slashbooks](https://github.com/giltotherescue/slashbooks) - Import bank and card activity, close the month, and export files for your accountant.
 
 ## DevOps
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -234,6 +234,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | salespeak-ai/buyer-eval-skill | 结构化 B2B 软件供应商评估：7 维度评分与证据追踪的评分卡，用于采购与自建/采购决策 | All | [GitHub](https://github.com/salespeak-ai/buyer-eval-skill) |
 | changelog-generator | 从 Git 提交自动生成 Changelog | Claude | [ComposioHQ](https://github.com/ComposioHQ/awesome-claude-skills) |
 | wiki | 构建带索引的 Markdown 知识库，供 Agent 映射、搜索、读取、更新与检查 | Claude/Codex | [GitHub](https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md) |
+| Slashbooks | 导入银行与信用卡流水，完成月度结账，并导出会计所需文件 | Claude/Codex/Cursor | [GitHub](https://github.com/giltotherescue/slashbooks) |
 
 ## DevOps
 


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: Slashbooks
**链接 / Link**: https://github.com/giltotherescue/slashbooks
**描述 / Description**: Import bank and card activity, close the month, and export files for your accountant.
**分类 / Category**: Productivity
**类型 / Type**: Single Skill

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate
- [x] 放在正确分类 / Placed in correct category
- [x] 没有为单个项目新增独立 section / Did not create a standalone section for a single project
- [x] 保持分类现有顺序 / Preserves the category's existing order
- [x] 单个 Skill 仓库包含 SKILL.md（如适用） / Single Skill repository contains SKILL.md (if applicable)

## 其他说明 / Additional Notes

One plugin/product listing only. Slashbooks is an open-source alternative to QuickBooks: an AI agent you control imports bank and card activity, closes the month, and creates the files your accountant needs. Homepage: https://slashbooks.org — License: Apache-2.0.