### PR TITLE
Add poka-yoke mistake-proofing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Skills work across multiple platforms:
 - [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Skills pack for Claude Code and Codex covering code review and grading, design, marketing and SEO, agent workflows, and mobile app shipping.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 - [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcript, video search, channel and playlist skills for Claude Code, OpenClaw, Hermes Agent, and other agent runtimes.
+- [poka-yoke](https://github.com/rainmanjam/poka-yoke) - Mistake-proofing skills for Claude Code and Codex: audit code for footguns, design APIs where misuse cannot be expressed, and turn incidents into devices
 
 ## Development Tools
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -185,6 +185,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | suede-creator-skills | 面向 Claude Code 与 Codex 的 Skills 合集，覆盖代码质量与评审、设计、营销与 SEO、Agent 工作流和移动应用发布 | 152 | [GitHub](https://github.com/JasonColapietro/suede-creator-skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
 | youtube-skills | 面向 YouTube 的转录、视频搜索、频道浏览与播放列表 Skills，适用于 Claude Code、OpenClaw、Hermes Agent 等 Agent 运行时 | 551 | [GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
+| poka-yoke | 面向 Claude Code 与 Codex 的防错（poka-yoke）Skills 合集，覆盖代码隐患审计、让误用无法表达的 API 设计，以及把事故转化为防错装置 | 1 | [GitHub](https://github.com/rainmanjam/poka-yoke) |
 
 ## 开发工具
 


### PR DESCRIPTION
Adds **poka-yoke** to Skills Collections, in both `README.md` and `README_ZH.md` (`Skills 合集`,
the table that carries a Stars column).

Eleven skills plus a dependency-free hazard scanner, applying Shigeo Shingo's mistake-proofing
method to code: prefer a device that makes a wrong action impossible or self-announcing over an
instruction asking someone to avoid it. Works with Claude Code and Codex; ships manifests for
19 runtimes.

- Repo: https://github.com/rainmanjam/poka-yoke
- License: MIT

One line in each file, nothing else touched.