### PR TITLE
Add SandBase CLI Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Skills work across multiple platforms:
 - [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Skills pack for Claude Code and Codex covering code review and grading, design, marketing and SEO, agent workflows, and mobile app shipping.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 - [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcript, video search, channel and playlist skills for Claude Code, OpenClaw, Hermes Agent, and other agent runtimes.
+- [sandbaseai/cli](https://github.com/sandbaseai/cli/tree/main/skills/sandbase) - Official SandBase Skill and MCP bridge for supported clients and 2,000+ AI models and APIs.
 
 ## Development Tools
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -185,6 +185,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | suede-creator-skills | 面向 Claude Code 与 Codex 的 Skills 合集，覆盖代码质量与评审、设计、营销与 SEO、Agent 工作流和移动应用发布 | 152 | [GitHub](https://github.com/JasonColapietro/suede-creator-skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
 | youtube-skills | 面向 YouTube 的转录、视频搜索、频道浏览与播放列表 Skills，适用于 Claude Code、OpenClaw、Hermes Agent 等 Agent 运行时 | 551 | [GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
+| sandbaseai/cli | 官方 SandBase Skill 与 MCP 桥接，连接受支持的客户端和 2,000+ AI 模型及 API | 66 | [GitHub](https://github.com/sandbaseai/cli) |
 
 ## 开发工具
 


### PR DESCRIPTION
Adds the official SandBase Agent Skill to Skills Collections in both README.md and README_ZH.md.

- Source: https://github.com/sandbaseai/cli/tree/main/skills/sandbase
- Description follows the repository format and documents the local MCP bridge plus 2,000+ AI model/API access.
- The Chinese row records the current 66-star count, satisfying the community-project threshold.
- Disclosure: I am affiliated with SandBase and used AI assistance to prepare this factual entry.