### PR TITLE
Add falsify — scientific thinking protocol skill (Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills work across multiple platforms:
 - [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring and evidence-tracked scorecards for procurement and build-vs-buy decisions.
 - [changelog-generator](https://github.com/ComposioHQ/awesome-claude-skills) - Generate changelogs from Git commits.
 - [wiki](https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md) - Build indexed Markdown knowledge bases that agents map, search, read, update, and lint.
+- [falsify](https://github.com/263311487-ux/falsify) - Scientific thinking protocol for AI agents: falsify first, then believe; evidence-graded conclusions with 28 built-in eval cases (Codex / Claude / Cursor / Gemini CLI).
 
 ## DevOps
 
@@ -243,3 +244,4 @@ PayPal: [paypal.me/JackyST0](https://paypal.me/JackyST0)
 ### Star History
 
 [![Star History Chart](https://star-history.dera.page/svg?repos=JackyST0/awesome-agent-skills&type=Date)](https://star-history.dera.page/#JackyST0/awesome-agent-skills&Date)
+

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -234,6 +234,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | salespeak-ai/buyer-eval-skill | 结构化 B2B 软件供应商评估：7 维度评分与证据追踪的评分卡，用于采购与自建/采购决策 | All | [GitHub](https://github.com/salespeak-ai/buyer-eval-skill) |
 | changelog-generator | 从 Git 提交自动生成 Changelog | Claude | [ComposioHQ](https://github.com/ComposioHQ/awesome-claude-skills) |
 | wiki | 构建带索引的 Markdown 知识库，供 Agent 映射、搜索、读取、更新与检查 | Claude/Codex | [GitHub](https://github.com/plasma-ai/wiki/blob/main/wiki/skills/wiki/SKILL.md) |
+| falsify | ⭐ 科学思维协议：先证伪，再相信；结论带证据强度分级，内置 28 个评测用例，蒸馏自 70+ 社区来源与认知科学/因果推断文献 | All | [GitHub](https://github.com/263311487-ux/falsify) |
 
 ## DevOps
 
@@ -325,3 +326,4 @@ my-skill/
 ### Star History
 
 [![Star History Chart](https://star-history.dera.page/svg?repos=JackyST0/awesome-agent-skills&type=Date)](https://star-history.dera.page/#JackyST0/awesome-agent-skills&Date)
+


### PR DESCRIPTION
## 新增技能

[falsify](https://github.com/263311487-ux/falsify) — 给 AI 智能体安装科学思维协议：

- **核心**: 先证伪，再相信；先标不确定，再下结论（无可证伪假设就没有结论）
- **兼容**: Codex / Claude Code / DeepSeek Harness / Cursor / Gemini CLI 等 20+ 智能体，单一 Markdown 即装即用
- **可验证**: 内置 28 个评测用例（evals/cases.md），每条结论带证据强度分级
- **质量**: 蒸馏自 70+ 社区来源与认知科学/因果推断文献，MIT 协议
- **安装**: `npx falsify-skill` 或 skills.sh 一键安装

已加入「Productivity / 效率提升」分类（英文 + 中文 README 同步）。