### PR TITLE
Add d1v DevOps skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Skills work across multiple platforms:
 - [ci-cd](https://claude-plugins.dev/skills/@ahmedasmar/devops-claude-skills/ci-cd) - Design, optimize, and security-scan CI/CD pipelines.
 - [claudekit-skills](https://github.com/mrgoonie/claudekit-skills) - Docker/GCP/Cloudflare deployment and management.
 - [claudebox](https://github.com/RchGrav/claudebox) - Dockerized Claude Code dev environment.
+- [d1v](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md) - Deploy web projects with verified previews and explicit-confirmation production releases.
 
 ## Data Processing
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -244,6 +244,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | ci-cd | CI/CD 管道设计、优化和安全扫描 | All | [claude-plugins.dev](https://claude-plugins.dev/skills/@ahmedasmar/devops-claude-skills/ci-cd) |
 | claudekit-skills | Docker/GCP/Cloudflare 部署和管理 | Claude | [GitHub](https://github.com/mrgoonie/claudekit-skills) |
 | claudebox | Docker 容器化 Claude Code 开发环境 | Claude | [GitHub](https://github.com/RchGrav/claudebox) |
+| d1v | 部署 Web 项目，提供可验证预览和需明确确认的生产发布 | Claude/Codex | [GitHub](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md) |
 
 ## 数据处理
 


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: d1v  
**链接 / Link**: https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md  
**描述 / Description**: Deploy web projects with verified previews and explicit-confirmation production releases. / 部署 Web 项目，提供可验证预览和需明确确认的生产发布。  
**分类 / Category**: DevOps  
**类型 / Type**: Official Resource / Single Skill

The canonical Skill is maintained by the d1v project and explicitly supports Claude Code and Codex. It contains a public `SKILL.md`; the repository is MIT-licensed.

Disclosure: submitted on behalf of the d1v project.

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate
- [x] 放在正确分类 / Placed in correct category
- [x] 没有为单个项目新增独立 section / Did not create a standalone section for a single project
- [x] 保持该分类现有的有意义顺序 / Preserves the category's existing meaningful order
- [x] 单个 Skill 仓库包含 SKILL.md / Single Skill repository contains SKILL.md
- [x] 官方资源，适用星标门槛豁免 / Official resource; star threshold exemption applies
- [x] 未手动修改 docs/skills.json / No manual edit to docs/skills.json

## 其他说明 / Additional Notes

- Only `README.md` and `README_ZH.md` are changed.
- `git diff --check` passes.
- No target-project dependencies, builds, or tests were run for this documentation-only PR.