### PR TITLE
Add claude-skills-pro to Skills Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Skills work across multiple platforms:
 - [awesome-claude-skills](https://github.com/VoltAgent/awesome-claude-skills) - Claude Skills collection by VoltAgent.
 - [claude-skills](https://github.com/simonw/claude-skills) - Claude Skills documentation by Simon Willison.
 - [claude-skills-collection](https://github.com/abubakarsiddik31/claude-skills-collection) - Curated official and community Skills.
+- [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) - 15 engineering-workflow skills (review, debugging, testing, safe migrations); 7 free/MIT, SKILL.md format, installs into 75+ agents.
 - [cursor-rules-and-prompts](https://github.com/thehimel/cursor-rules-and-prompts) - Cursor rules and prompts collection.
 - [Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) - Universal AI Skills installer (Homebrew for Skills).
 - [claude-code-kit](https://github.com/blencorp/claude-code-kit) - Claude Code toolkit with auto-activating skills.


### PR DESCRIPTION
Adds [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) — 15 engineering-workflow skills in the open SKILL.md format:

- **7 of the 15 are free/open-source (MIT)** in the same repo (pr-reviewer, bug-hunter, test-forge, feature-spec, commit-craft, changelog-release, ai-code-reviewer)
- Installs via `npx skills add Hahaknight/claude-skills-pro` — works with Claude Code, Codex, Gemini CLI, Qwen Code, goose, crush and 75+ other agents (I verified the gemini/goose/crush/codex/qwen-code paths end-to-end)
- Bilingual README (EN + 中文); the paid Pro pack adds 8 more skills + a Chinese handbook

One line added to Skills Collections, alphabetical cluster with the other claude-* entries. Happy to adjust format if needed.
