### PR TITLE
Add stipple-agent-skills to Skills Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Skills work across multiple platforms:
 - [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Skills pack for Claude Code and Codex covering code review and grading, design, marketing and SEO, agent workflows, and mobile app shipping.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 - [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcript, video search, channel and playlist skills for Claude Code, OpenClaw, Hermes Agent, and other agent runtimes.
+- [stipple-agent-skills](https://github.com/Sketchjar/stipple-agent-skills) - Document trust skills: forensic document authenticity, citation verification, grounded extraction, AI-text detection, identity checks, adverse-media screening, AU/NZ tender search. Free anonymous tier.
 
 ## Development Tools
 


### PR DESCRIPTION
## What

Adds [Sketchjar/stipple-agent-skills](https://github.com/Sketchjar/stipple-agent-skills) to the Skills Collections section.

7 document-trust skills: forensic document authenticity, citation verification, grounded extraction, AI-text detection, identity checks, adverse-media screening, AU/NZ tender search. Free anonymous tier, no signup.

## Format

Follows the existing Skills Collections entry format: `- [name](url) - description`.