### PR TITLE
docs: add flaqai/backlink_skills to Skills Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Skills work across multiple platforms:
 - [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Skills pack for Claude Code and Codex covering code review and grading, design, marketing and SEO, agent workflows, and mobile app shipping.
 - [unifapi-agent/skills](https://github.com/unifapi-agent/skills) - Public-data MCP and KOL pricing Skills for Codex, Claude Code, Cursor, and other agents.
 - [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcript, video search, channel and playlist skills for Claude Code, OpenClaw, Hermes Agent, and other agent runtimes.
+- [flaqai/backlink_skills](https://github.com/flaqai/backlink_skills) - Open-source Codex skills for evidence-first product-directory qualification, authorization, verification, and SEO content workflows.
 
 ## Development Tools
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -185,6 +185,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | suede-creator-skills | 面向 Claude Code 与 Codex 的 Skills 合集，覆盖代码质量与评审、设计、营销与 SEO、Agent 工作流和移动应用发布 | 129 | [GitHub](https://github.com/JasonColapietro/suede-creator-skills) |
 | unifapi-agent/skills | 基于 UnifAPI MCP 的公共数据与 KOL 定价 Skills | 481 | [GitHub](https://github.com/unifapi-agent/skills) |
 | youtube-skills | 面向 YouTube 的转录、视频搜索、频道浏览与播放列表 Skills，适用于 Claude Code、OpenClaw、Hermes Agent 等 Agent 运行时 | 585 | [GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
+| flaqai/backlink_skills | 开源 Codex Skills，覆盖证据优先的产品目录筛选、授权验证与 SEO 内容工作流 | 626 | [GitHub](https://github.com/flaqai/backlink_skills) |
 
 ## 开发工具
 


### PR DESCRIPTION
## 添加条目 / Add Entry

**名称 / Name**: flaqai/backlink_skills
**链接 / Link**: https://github.com/flaqai/backlink_skills
**描述 / Description**: Open-source Codex skills for evidence-first product-directory qualification, authorization, verification, and SEO content workflows.
**分类 / Category**: Skills Collections / Skills 合集
**类型 / Type**: Skills Collection

The repository contains two focused product-directory submission Skills (`SKILL.md`), supporting references/scripts/tests, and platform-specific SEO writing workflows. The directory workflow emphasizes truthful product information, authorization and verification gates, privacy-safe evidence, and excludes bulk spam, ranking manipulation, paid link acquisition, and low-quality automated submissions.

## 检查清单 / Checklist

- [x] 链接有效 / Link is valid (GitHub and canonical Skill path return HTTP 200)
- [x] 同时更新了 README.md 和 README_ZH.md / Updated both README.md and README_ZH.md
- [x] 描述准确 / Description is accurate and non-promotional
- [x] 放在正确分类 / Placed in correct category: Skills Collections
- [x] 没有为单个项目新增独立 section / Did not create a standalone section
- [x] 保持分类现有顺序 / Preserves the existing order by appending one entry
- [x] Skills 合集明确服务于 Skills 生态 / The repository is a public Skills collection with multiple `SKILL.md` entries
- [x] 社区项目满足最低门槛（64+ Stars，如适用） / Meets the 64+ community threshold (626 stars at submission)

## 其他说明 / Additional Notes

- The source repository is public and MIT-licensed.
- This is a first-party/self-submission by the source maintainer/organization (`flaqai`); no third-party endorsement is implied.
- AI assistance was used to prepare the documentation-only change; the submitting account reviewed the final content.
- `docs/skills.json` was not edited; it is generated automatically after merge.
- This link is only a candidate listing until the PR is reviewed and merged; no inclusion or traffic is claimed.
