### PR TITLE
Add orca-replay to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Skills work across multiple platforms:
 ## Development Tools
 
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/blob/master/skills/agenttrace-session-audit/SKILL.md) - Audit local AI coding-agent session health, cost, failures, and diffs.
+- [orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay) - Read a recorded agent run from its trace: what it actually sent, ran and changed, plus offline replay and forking.
 - [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) - Production-grade engineering skills and slash-command workflows for AI coding agents.
 - [claude-code-security-review](https://github.com/anthropics/claude-code-security-review) - AI security review GitHub Action (Official).
 - [trailofbits/skills](https://github.com/trailofbits/skills) - Trail of Bits security research and audit Skills.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Skills work across multiple platforms:
 ## Development Tools
 
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/blob/master/skills/agenttrace-session-audit/SKILL.md) - Audit local AI coding-agent session health, cost, failures, and diffs.
-- [orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay) - Read a recorded agent run from its trace: what it actually sent, ran and changed, plus offline replay and forking.
+- [orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay) - Read a recorded agent run from its trace: what it actually sent, ran and changed. Replay is offline for the model only — the recorded shell commands re-execute for real and `worktree` isolation is not a sandbox, so the skill requires checking side effects first.
 - [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) - Production-grade engineering skills and slash-command workflows for AI coding agents.
 - [claude-code-security-review](https://github.com/anthropics/claude-code-security-review) - AI security review GitHub Action (Official).
 - [trailofbits/skills](https://github.com/trailofbits/skills) - Trail of Bits security research and audit Skills.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -191,6 +191,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | 名称 | 描述 | 平台 | 链接 |
 |------|------|------|------|
 | agenttrace-session-audit | 审计本地 AI 编程 Agent 会话的健康度、成本、失败与差异 | All | [GitHub](https://github.com/luoyuctl/agenttrace/blob/master/skills/agenttrace-session-audit/SKILL.md) |
+| orca-replay | 从录像回答 Agent 那次运行到底做了什么：发出的请求、每次工具调用、shell 退出码与文件改动，并可离线重放或从检查点分叉。重放只阻断模型侧出网，录下的 shell 命令会真的再执行一次，`worktree` 隔离也不等于沙箱，因此技能要求先确认副作用再重放 | All | [GitHub](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay) |
 | addyosmani/agent-skills | 面向 AI 编程代理的生产级工程技能与斜杠命令工作流 | All | [GitHub](https://github.com/addyosmani/agent-skills) |
 | claude-code-security-review | ⭐ AI 安全审查 GitHub Action（官方） | Claude | [GitHub](https://github.com/anthropics/claude-code-security-review) |
 | trailofbits/skills | ⭐ Trail of Bits 安全研究和审计 Skills | Claude | [GitHub](https://github.com/trailofbits/skills) |


### PR DESCRIPTION
Adds the `orca-replay` skill to **Development Tools**, next to `agenttrace-session-audit`, which addresses the same question from a different angle.

The skill tells an agent to answer "why did the earlier run do that" from a **recording** rather than from memory or a pasted transcript, and to keep what the trace actually shows separate from what it is inferring. Behind it, OrcaReplay records at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls sit on one timeline — and the run can be replayed offline with the network off, or forked from a checkpoint onto a different model.

The skill is Apache-2.0 and lives at `skills/orca-replay/SKILL.md` in the linked repo. The same file was reviewed and merged into `sickn33/agentic-awesome-skills` and is published on ClawHub, where the security scan cleared it. It needs the `orcareplay` npm package with its MCP server registered — that dependency is stated in the skill's own frontmatter, so nobody discovers it halfway through.
