### PR TITLE
Add pit-stop to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills work across multiple platforms:
 - [debug-helper](https://github.com/JackyST0/awesome-agent-skills/tree/main/examples/debug-helper) - Code debugging assistant Skill.
 - [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents with encrypted local vault storage and proxy-based credential injection.
 - [Sverklo](https://github.com/sverklo/sverklo) - Local-first repo-memory MCP for coding agents: proof receipts, symbol refs, impact, and diff review.
+- [pit-stop](https://github.com/Finn763/pit-stop) - One instruction runs a full codebase improvement loop: find → fix → verify → report, every finding with path:line evidence.
 
 ## Productivity
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -214,6 +214,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | debug-helper | 代码调试助手 Skill | All | [示例](examples/debug-helper/) |
 | authsome | AI Agent 本地凭据代理，加密本地保管库与基于代理的凭据注入 | All | [GitHub](https://github.com/agentrhq/authsome) |
 | Sverklo | 本地优先的仓库记忆 MCP，支持证明回执、符号引用、影响分析与差异审查 | All | [GitHub](https://github.com/sverklo/sverklo) |
+| Finn763/pit-stop | 一条指令跑完整个代码库改进循环：发现 → 修复 → 验证 → 报告，每条发现都带 path:line 证据 | All | [GitHub](https://github.com/Finn763/pit-stop) |
 
 ## 效率提升
 


### PR DESCRIPTION
Add [Finn763/pit-stop](https://github.com/Finn763/pit-stop): one-line instruction runs a full codebase improvement loop (read → find → fix → verify → report) with evidence-before-claims reporting. Cross-runtime (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Hermes, Pi). Install: `npx skills add Finn763/pit-stop`.

Note on the 64-star guideline: pit-stop is brand new (published 2026-09-06, 0 stars so far) — flagging that upfront. Happy to resubmit once it clears the threshold if you prefer.