### PR TITLE
Add humanizer-ru to Writing / 写作创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Skills work across multiple platforms:
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Portable document format processing Skill.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - PowerPoint presentation generator Skill.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Excel spreadsheet processing Skill.
+- [humanizer-ru](https://github.com/ilyautov/humanizer-ru) - Removes AI-generation markers from Russian text, with a deterministic scanner.
 
 ## Design
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -265,6 +265,7 @@ git clone https://github.com/example/my-skill.git ~/.cursor/skills/my-skill
 | pdf | ⭐ PDF 文档处理 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/pdf) |
 | pptx | ⭐ PPT 演示文稿生成 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/pptx) |
 | xlsx | ⭐ Excel 表格处理 Skill | Claude | [官方](https://github.com/anthropics/skills/tree/main/skills/xlsx) |
+| humanizer-ru | 清除俄语文本中的 AI 生成痕迹，内置确定性扫描器 | All | [GitHub](https://github.com/ilyautov/humanizer-ru) |
 
 ## 设计相关
 


### PR DESCRIPTION
## 添加条目

**名称**：humanizer-ru
**链接**：https://github.com/ilyautov/humanizer-ru
**描述**：Removes AI-generation markers from Russian text, with a deterministic scanner. 清除俄语文本中的 AI 生成痕迹，内置确定性扫描器。
**分类**：Writing / 写作创作
**类型**：单个 Skill

## 检查清单

- [x] 链接有效
- [x] 同时更新了 README.md 和 README_ZH.md
- [x] 描述准确
- [x] 放在正确分类
- [x] 没有为单个项目新增独立 section
- [x] 保持该分类现有的有意义顺序，条目加在末尾
- [x] 单个 Skill 仓库包含 SKILL.md（`skills/humanizer-ru/SKILL.md`）
- [x] GitHub 仓库满足最低门槛：337 stars

## 补充

The skill targets Russian specifically: Russian AI text has its own markers (bureaucratese, English calques, nominal style) that English humanizers do not catch. It ships `scripts/scan.py`, a deterministic scanner that reports a 0-100 cleanliness score, plus an eval harness with before/after metrics. MIT, installable with `npx skills add ilyautov/humanizer-ru`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)